### PR TITLE
add print-config-path argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,15 @@ either:
    fmrl -c path/to/config.json
    ```
 
-2. or... (recommended for default config) save the file in one of these locations and then fmrl will use that by default:
+2. (recommended) save the file in this location, and then fmrl will use that by default:
+
+   To see the location `fmrl` will look for a default config file, run this command:
+
+   ```bash
+   fmrl --print-config-path
+   ```
+
+Here are the default locations
 
 - Mac: `$HOME/Library/Application Support/fm_rainbow_log/config.json`
   - example: `/Users/Alice/Library/Application Support/fm_rainbow_log/config.json`

--- a/src/config_file.rs
+++ b/src/config_file.rs
@@ -50,7 +50,7 @@ where
         .collect())
 }
 
-fn get_default_config_path() -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+pub(crate) fn get_default_config_path() -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
     Ok(dirs::config_dir()
         .ok_or("couldn't find config directory")?
         .join("fm_rainbow_log")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,7 @@ mod utils;
 
 use beeper::beep;
 use color_type::ColorType;
-use config_file::{get_config, update_args_from_config, ConfigColor};
+use config_file::{get_config, get_default_config_path, update_args_from_config, ConfigColor};
 use error_rule::{apply_error_rules, ErrorRule, ErrorRuleAction};
 use notifications::NotificationType;
 use rules::{contains_warning_text, is_header, is_operation_start};
@@ -141,6 +141,9 @@ pub struct Args {
         value_name = "PATH"
     )]
     config_path: Option<String>,
+
+    #[arg(long, help = "print the default config path")]
+    print_config_path: bool,
 
     #[arg(long, help = "generate completion script")]
     completion: Option<Shell>,
@@ -389,6 +392,11 @@ pub fn run() -> CustomResult {
     if let Some(gen) = args.completion {
         let mut cmd = Args::command();
         generate_completion_script(gen, &mut cmd);
+        return Ok(());
+    }
+    if args.print_config_path {
+        let path = get_default_config_path()?;
+        println!("{}", path.to_string_lossy());
         return Ok(());
     }
 


### PR DESCRIPTION
makes it easier for users to quickly find the location to create the default config.json file.
